### PR TITLE
fix for OpenCv 4.x.x

### DIFF
--- a/TextDetect.py
+++ b/TextDetect.py
@@ -12,8 +12,12 @@ def text_detect(img,ele_size=(8,2)): #
     img_threshold = cv2.threshold(img_sobel,0,255,cv2.THRESH_OTSU+cv2.THRESH_BINARY)
     element = cv2.getStructuringElement(cv2.MORPH_RECT,ele_size)
     img_threshold = cv2.morphologyEx(img_threshold[1],cv2.MORPH_CLOSE,element)
-    contours = cv2.findContours(img_threshold,0,1)
-    Rect = [cv2.boundingRect(i) for i in contours[1] if i.shape[0]>100]
+    res = cv2.findContours(img_threshold, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE)
+    if cv2.__version__.split(".")[0] == '3':
+        _, contours, hierarchy = res
+    else:
+        contours, hierarchy = res
+    Rect = [cv2.boundingRect(i) for i in contours if i.shape[0]>100]
     RectP = [(int(i[0]-i[2]*0.08),int(i[1]-i[3]*0.08),int(i[0]+i[2]*1.1),int(i[1]+i[3]*1.1)) for i in Rect]
     return RectP
 


### PR DESCRIPTION
for opencv ver=3.x.x cv2.findContours returns 3 value image, contours, hierarchy
for opencv ver<>3.x.x cv2.findContours returns 2 value contours, hierarchy
https://docs.opencv.org/2.4/modules/imgproc/doc/structural_analysis_and_shape_descriptors.html?highlight=findcontours#findcontours
https://docs.opencv.org/3.4.6/d3/dc0/group__imgproc__shape.html#ga17ed9f5d79ae97bd4c7cf18403e1689a
https://docs.opencv.org/4.1.1/d3/dc0/group__imgproc__shape.html#gadf1ad6a0b82947fa1fe3c3d497f260e0